### PR TITLE
Add 2.5x and 3x speed buttons

### DIFF
--- a/src/components/PredefinedButtonsGroup.tsx
+++ b/src/components/PredefinedButtonsGroup.tsx
@@ -5,7 +5,7 @@ export const PredefinedButtonsGroup = () => {
   const { currentSpeed, setCurrentSpeed } = useSettings();
   return (
     <div className={styles.container}>
-      {[0.5, 1, 1.5, 2].map((speed) => (
+      {[0.5, 1, 1.5, 2, 2.5, 3].map((speed) => (
         <button
           className={[
             styles.button,


### PR DESCRIPTION
There's so much space for more buttons so this PR adds 2 more buttons for common speeds.

My old speed extension no longer works with Chrome and it had a 2.5x and 3x option I used often. Would love if these got added 🙏